### PR TITLE
添加鼠标绘制工具条库

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ typings/
 *.ipr
 *.iws
 .idea/
+
+.history/

--- a/.kktrc.ts
+++ b/.kktrc.ts
@@ -24,6 +24,7 @@ export const moduleScopePluginOpts = [
   path.resolve(process.cwd(), 'src/Polyline/README.md'),
   path.resolve(process.cwd(), 'src/TileLayer/README.md'),
   path.resolve(process.cwd(), 'src/CurveLine/README.md'),
+  path.resolve(process.cwd(), 'src/DrawingManager/README.md'),
   path.resolve(process.cwd(), 'src/Polygon/README.md'),
   path.resolve(process.cwd(), 'src/withMap/README.md'),
 ];

--- a/package.json
+++ b/package.json
@@ -73,11 +73,11 @@
     "react-router-dom": "^5.1.2",
     "react-test-renderer": "^16.8.6",
     "tsbb": "^1.5.2",
+    "typescript": "^3.8.3",
     "uiw": "^3.10.6"
   },
   "dependencies": {
-    "@babel/runtime": "^7.8.4",
-    "typescript": "^3.8.3"
+    "@babel/runtime": "^7.8.4"
   },
   "eslintConfig": {
     "extends": "react-app",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "@types/classnames": "^2.2.7",
     "@types/jest": "^25.1.4",
     "@types/loadable__component": "^5.10.0",
-    "@types/node": "^12.12.28",
-    "@types/react": "^16.9.21",
+    "@types/node": "^12.12.31",
+    "@types/react": "^16.9.25",
     "@types/react-dom": "^16.9.5",
     "@types/react-router-dom": "^5.1.3",
     "@types/react-test-renderer": "^16.9.2",
@@ -76,7 +76,8 @@
     "uiw": "^3.10.6"
   },
   "dependencies": {
-    "@babel/runtime": "^7.8.4"
+    "@babel/runtime": "^7.8.4",
+    "typescript": "^3.8.3"
   },
   "eslintConfig": {
     "extends": "react-app",

--- a/src/CurveLine/useCurveLine.tsx
+++ b/src/CurveLine/useCurveLine.tsx
@@ -14,12 +14,34 @@ export default (props = {} as UseCurveLine) => {
   const [loadMapLib, setLoadBMapLib] = useState(false || !!libSDK);
   const opts = { strokeColor, strokeWeight, strokeOpacity, strokeStyle, enableMassClear, enableClicking, icons, }
   useMemo(() => {
+    // 如果第一次加载，会执行下面的
     if (map && bMapLib && !curveLine) {
-      const points = (props.path || []).map((item) => new BMap.Point(item.lng, item.lat));
-      const instance = new BMapLib.CurveLine(points, opts);
-      map.addOverlay(instance);
-      setCurveLine(instance);
+      if(bMapLib.CurveLine) {
+        const points = (props.path || []).map((item) => new BMap.Point(item.lng, item.lat));
+        const instance = new BMapLib.CurveLine(points, opts);
+        map.addOverlay(instance);
+        setCurveLine(instance);
+      }
     }
+
+    // 如果 bMapLib 已经加载过，会执行下面的
+    if(map && bMapLib && !bMapLib.CurveLine) {
+      requireScript('//api.map.baidu.com/library/CurveLine/1.5/src/CurveLine.min.js').then(() => {
+        if (window.BMapLib) {
+          const newMapLib = Object.assign(window.BMapLib, bMapLib)
+          setBMapLib(newMapLib)
+
+          const points = (props.path || []).map((item) => new BMap.Point(item.lng, item.lat));
+          const instance = new BMapLib.CurveLine(points, opts);
+          map.addOverlay(instance);
+          setCurveLine(instance);
+        }
+      }).catch(() => {
+
+      });
+    }
+
+    // 如果第一次加载，会执行下面的
     if (!bMapLib && !loadMapLib) {
       setLoadBMapLib(true);
       requireScript('//api.map.baidu.com/library/CurveLine/1.5/src/CurveLine.min.js').then(() => {

--- a/src/CustomOverlay/useCustomOverlay.tsx
+++ b/src/CustomOverlay/useCustomOverlay.tsx
@@ -61,7 +61,7 @@ export default (props = {} as UseCustomOverlay) => {
   const { map, children, paneName, position } = props;
   const [customOverlay, setCustomOverlay] = useState<BMap.Overlay>();
   const [div, setDiv] = useState<HTMLDivElement>();
-  const [portal, setPortal] = useState();
+  const [portal, setPortal] = useState<React.ReactPortal>();
   const [count, setCount] = useState(0);
   useMemo(() => {
     if (map && !portal) {

--- a/src/DrawingManager/README.md
+++ b/src/DrawingManager/README.md
@@ -1,0 +1,149 @@
+# 鼠标绘制工具条库
+
+> 提供鼠标绘制点、线、面、多边形（矩形、圆）的编辑工具条的开源代码库。且用户可使用 JavaScript API 对应覆盖物（点、线、面等）类接口对其进行属性（如颜色、线宽等）设置、编辑（如开启线顶点编辑等）等功能
+
+当前组件自动加载 [DrawingManager_min.js](http://api.map.baidu.com/library/DrawingManager/1.4/src/DrawingManager_min.js)，加载完成将会有个 `window.BMapLib` 的全局对象。
+
+```jsx
+import { DrawingManager, useDrawingManager } from '@uiw/react-baidu-map'
+```
+
+### 基本用法
+
+<!--DemoStart,bgWhite-->
+
+```jsx
+import React, { useState } from 'react'
+import { Map, DrawingManager, APILoader } from '@uiw/react-baidu-map'
+
+const styleOptions = {
+  strokeColor: 'red', //边线颜色。
+  fillColor: 'red', //填充颜色。当参数为空时，圆形将没有填充效果。
+  strokeWeight: 3, //边线的宽度，以像素为单位。
+  strokeOpacity: 0.8, //边线透明度，取值范围0 - 1。
+  fillOpacity: 0.6, //填充的透明度，取值范围0 - 1。
+  strokeStyle: 'solid' //边线的样式，solid或dashed。
+}
+
+const Example = () => {
+  return (
+    <>
+      <Map zoom={4} center="武汉" widget={['NavigationControl']}>
+        <DrawingManager
+          isOpen={true}
+          enableDrawingTool={true}
+          drawingToolOptions={{
+            anchor: BMAP_ANCHOR_TOP_RIGHT,
+            offset: new BMap.Size(5, 5)
+          }}
+          circleOptions={styleOptions}
+          polylineOptions={styleOptions}
+          polygonOptions={styleOptions}
+          rectangleOptions={styleOptions}
+        />
+      </Map>
+    </>
+  )
+}
+
+const Demo = () => (
+  <div style={{ width: '100%', height: '350px' }}>
+    <APILoader akay="GTrnXa5hwXGwgQnTBG28SHBubErMKm3f">
+      <Example />
+    </APILoader>
+  </div>
+)
+ReactDOM.render(<Demo />, _mount_)
+```
+
+<!--End-->
+
+### 使用 hooks
+
+<!--DemoStart,bgWhite-->
+
+```jsx
+import { useRef, useEffect, useState } from 'react'
+import { Map, APILoader, useMap, useDrawingManager } from '@uiw/react-baidu-map'
+
+const Example = () => {
+
+  const styleOptions = {
+    strokeColor: 'red', //边线颜色。
+    fillColor: 'red', //填充颜色。当参数为空时，圆形将没有填充效果。
+    strokeWeight: 3, //边线的宽度，以像素为单位。
+    strokeOpacity: 0.8, //边线透明度，取值范围0 - 1。
+    fillOpacity: 0.6, //填充的透明度，取值范围0 - 1。
+    strokeStyle: 'solid' //边线的样式，solid或dashed。
+  }
+
+  const divElm = useRef(null)
+
+  const { setContainer, map } = useMap({
+    zoom: 8,
+    enableScrollWheelZoom: true,
+    widget: ['GeolocationControl', 'NavigationControl']
+  })
+
+  const { drawingManager } = useDrawingManager({
+    map,
+    isOpen: true, //是否开启绘制模式
+    enableDrawingTool: true, //是否显示工具栏
+    drawingToolOptions: {
+      anchor: BMAP_ANCHOR_TOP_RIGHT, //位置
+      offset: new BMap.Size(5, 5) //偏离值
+    },
+    circleOptions: styleOptions, //圆的样式
+    polylineOptions: styleOptions, //线的样式
+    polygonOptions: styleOptions, //多边形的样式
+    rectangleOptions: styleOptions //矩形的样式
+  })
+
+  useEffect(() => {
+    if (divElm.current && !map) {
+      setContainer(divElm.current)
+    }
+  }, [map])
+
+  return (
+    <>
+      <div ref={divElm} style={{ height: '100%' }} />
+    </>
+  )
+}
+
+const Demo = () => (
+  <div style={{ width: '100%', height: '300px' }}>
+    <APILoader akay="GTrnXa5hwXGwgQnTBG28SHBubErMKm3f">
+      <Example />
+    </APILoader>
+  </div>
+)
+ReactDOM.render(<Demo />, _mount_)
+```
+
+<!--End-->
+
+
+### Props
+
+| 参数 | 说明 | 类型 | 默认值 |
+| ----- | ----- | ----- | ----- |
+| isOpen | 是否开启绘制模式 | `boolean` | - |
+| enableDrawingTool |  是否添加绘制工具栏控件 | `boolean` | 默认不添加 |
+| drawingToolOptions |  折线的宽度，以像素为单位 | Json Object | 可选的输入参数，非必填项 |
+| enableCalculate |  绘制是否进行测距(画线时候)、测面(画圆、多边形、矩形) | `boolean` | - |
+
+### drawingToolOptions
+| 参数 | 说明 | 类型 | 默认值 |
+| ----- | ----- | ----- | ----- |
+| anchor | 是否开启绘制模式 | ControlAnchor | 停靠位置、默认左上角 |
+| offset | 偏移值 | BMap.Size | - |
+| scale | 工具栏的缩放比例,默认为1 | Number | - |
+| drawingModes | 工具栏上可以选择出现的绘制模式 | Array | - |
+
+### 官方文档
+demo: https://lbsyun.baidu.com/jsdemo.htm#f0_7
+
+api: http://api.map.baidu.com/library/DrawingManager/1.4/docs/symbols/BMapLib.DrawingManager.html
+

--- a/src/DrawingManager/index.tsx
+++ b/src/DrawingManager/index.tsx
@@ -1,0 +1,16 @@
+import React, { useImperativeHandle } from 'react'
+import useDrawingManager from './useDrawingManager'
+import { MapChildProps } from '../common/map'
+
+export interface DrawingManagerProps
+  extends BMap.DrawingManagerOptions,
+    MapChildProps {}
+
+export default React.forwardRef<
+  DrawingManagerProps & { drawingManager?: BMapLib.DrawingManager },
+  DrawingManagerProps
+>((props, ref) => {
+  const { drawingManager } = useDrawingManager(props)
+  useImperativeHandle(ref, () => ({ ...props, drawingManager, BMapLib }))
+  return null
+})

--- a/src/DrawingManager/useDrawingManager.tsx
+++ b/src/DrawingManager/useDrawingManager.tsx
@@ -1,0 +1,92 @@
+import { useState, useMemo } from 'react'
+import { DrawingManagerProps } from '.'
+import { requireScript, requireCss } from '../utils/requireScript'
+
+export interface UseDrawingManager extends DrawingManagerProps {}
+
+export default (props = {} as UseDrawingManager) => {
+  const {
+    map,
+    isOpen,
+    drawingMode,
+    enableDrawingTool,
+    enableCalculate,
+    drawingToolOptions,
+    markerOptions,
+    circleOptions,
+    polylineOptions,
+    polygonOptions,
+    rectangleOptions
+  } = props
+
+  const [drawingManager, setDrawingManager] = useState<BMapLib.DrawingManager>()
+  const libSDK = window.BMapLib
+  const [bMapLib, setBMapLib] = useState<typeof BMapLib>(libSDK)
+  const [loadMapLib, setLoadBMapLib] = useState(false || !!libSDK)
+  const opts = {
+    isOpen,
+    drawingMode,
+    enableDrawingTool,
+    enableCalculate,
+    drawingToolOptions,
+    markerOptions,
+    circleOptions,
+    polylineOptions,
+    polygonOptions,
+    rectangleOptions
+  } as BMap.DrawingManagerOptions
+
+  useMemo(() => {
+    // 如果第一次加载，会执行下面的
+    if (map && bMapLib && !drawingManager) {
+      if (bMapLib.DrawingManager) {
+        const instance = new BMapLib.DrawingManager(map, opts)
+        setDrawingManager(instance)
+      }
+    }
+
+    // 如果 bMapLib 已经加载过，会执行下面的
+    if (map && bMapLib && !bMapLib.DrawingManager) {
+      requireCss(
+        '//api.map.baidu.com/library/DrawingManager/1.4/src/DrawingManager_min.css'
+      ).then(() => {})
+
+      requireScript(
+        '//api.map.baidu.com/library/DrawingManager/1.4/src/DrawingManager_min.js'
+      )
+        .then(() => {
+          if (window.BMapLib) {
+            const newMapLib = Object.assign(window.BMapLib, bMapLib)
+            setBMapLib(newMapLib)
+
+            const instance = new BMapLib.DrawingManager(map, opts)
+            setDrawingManager(instance)
+          }
+        })
+        .catch(() => {})
+    }
+
+    // 如果第一次加载，会执行下面的
+    if (!bMapLib && !loadMapLib) {
+      setLoadBMapLib(true)
+      requireCss(
+        '//api.map.baidu.com/library/DrawingManager/1.4/src/DrawingManager_min.css'
+      ).then(() => {})
+      requireScript(
+        '//api.map.baidu.com/library/DrawingManager/1.4/src/DrawingManager_min.js'
+      )
+        .then(() => {
+          if (window.BMapLib) {
+            setBMapLib(window.BMapLib)
+          }
+        })
+        .catch(() => {})
+    }
+  }, [map, loadMapLib, bMapLib, drawingManager])
+
+  return {
+    drawingManager,
+    setDrawingManager,
+    BMapLib: bMapLib
+  }
+}

--- a/src/common/useCreatePortal.tsx
+++ b/src/common/useCreatePortal.tsx
@@ -11,7 +11,7 @@ export interface UseCreatePortal {
 
 export default (props = {} as UseCreatePortal) => {
   const [div, setDiv] = useState<HTMLDivElement>(document.createElement('div'));
-  const [portal, setPortal] = useState();
+  const [portal, setPortal] = useState<React.ReactPortal>();
   const [count, setCount] = useState(0);
   const [children, setChildren] = useState(props.children);
   useMemo(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,8 @@ export { default as PointCollection } from './PointCollection';
 export { default as usePointCollection } from './PointCollection/usePointCollection';
 export { default as CurveLine } from './CurveLine';
 export { default as useCurveLine } from './CurveLine/useCurveLine';
+export { default as DrawingManager } from './DrawingManager';
+export { default as useDrawingManager } from './DrawingManager/useDrawingManager';
 export { default as Polyline } from './Polyline';
 export { default as usePolyline } from './Polyline/usePolyline';
 export { default as Polygon } from './Polygon';

--- a/src/types/bmaplib.d.ts
+++ b/src/types/bmaplib.d.ts
@@ -1,19 +1,124 @@
 declare global {
   interface Window {
-    BMapLib: typeof BMapLib;
+    BMapLib: typeof BMapLib
+  }
+}
+
+declare namespace BMap {
+  interface DrawingManagerOptions {
+    /**
+     * 是否开启绘制模式
+     */
+    isOpen?: boolean
+
+    /**
+     * 当前的绘制模式, 默认是绘制点
+     */
+    drawingMode?: BMap.DrawingType
+
+    /**
+     * 是否添加绘制工具栏控件，默认不添加
+     */
+    enableDrawingTool?: boolean
+
+    /**
+     * 绘制是否进行测距(画线时候)、测面(画圆、多边形、矩形)
+     */
+    enableCalculate?: boolean
+
+    drawingToolOptions?: BMap.DrawingToolOptions
+
+    markerOptions?: BMap.CircleOptions
+    circleOptions?: BMap.CircleOptions
+    polylineOptions?: BMap.PolylineOptions
+    polygonOptions?: BMap.PolygonOptions
+    rectangleOptions?: BMap.PolygonOptions
+  }
+
+  interface DrawingToolOptions {
+    anchor?: BMap.ControlAnchor
+    offset?: BMap.Size
+    scale?: number
+    drawingModes?: BMap.DrawingType[]
   }
 }
 
 declare namespace BMapLib {
-  type Callback = (...args: any[]) => void;
+  type Callback = (...args: any[]) => void
+
+  type Callback<T> = (e: any, overlay: T) => void
+
   /**
    * 弧线
    */
   class CurveLine {
-    constructor(points: BMap.Point[], opts?: CurveLineOptions);
+    constructor(points: BMap.Point[], opts?: CurveLineOptions)
   }
-  interface CurveLineOptions extends BMap.PolylineOptions {}
-  interface CurveLine extends BMap.Polyline {}
-  interface CurveLineEvents extends BMap.PolylineEvents {}
+  interface CurveLineOptions extends BMap.PolylineOptions { }
+  interface CurveLine extends BMap.Polyline { }
+  interface CurveLineEvents extends BMap.PolylineEvents { }
 
+  /**
+   * 鼠标绘制管理
+   */
+  class DrawingManager {
+    constructor(map: BMap.Map, opts?: BMap.DrawingManagerOptions)
+
+    /**
+     * 开启地图的绘制状态
+     */
+    open(): void
+
+    /**
+     * 关闭地图的绘制状态
+     */
+    close(): void
+
+    /**
+     * 打开距离或面积计算
+     */
+    enableCalculate(): void
+
+    /**
+     * 关闭距离或面积计算
+     */
+    disableCalculate(): void
+
+    /**
+     * 获取当前的绘制模式
+     */
+    getDrawingMode(): BMap.DrawingType
+
+    /**
+     * 设置当前的绘制模式
+     * BMAP_DRAWING_MARKER    画点
+     * BMAP_DRAWING_CIRCLE    画圆
+     * BMAP_DRAWING_POLYLINE  画线
+     * BMAP_DRAWING_POLYGON   画多边形
+     * BMAP_DRAWING_RECTANGLE 画矩形
+     * @param drawingType 绘制模式
+     */
+    setDrawingMode(drawingType: BMap.DrawingType): void
+
+    /**
+     * 添加事件监听函数
+     * @param event 
+     * @param handler 
+     */
+    addEventListener(event: string, handler: Callback): void;
+
+    /**
+     * 添加事件监听函数
+     * @param event 
+     * @param handler 
+     */
+    addEventListener<T>(event: string, handler: Callback<T>): void;
+
+    /**
+     * 移除事件监听函数
+     * @param event 
+     * @param handler 
+     */
+    removeEventListener(event: string, handler: Callback): void;
+  }
 }

--- a/src/types/control.d.ts
+++ b/src/types/control.d.ts
@@ -268,6 +268,12 @@ declare namespace BMap {
   class PanoramaControl extends Control {
     constructor();
   }
+
+  /**
+   * 绘制模式
+   */
+  type DrawingType = string;
+
 }
 
 /**
@@ -312,6 +318,20 @@ declare const BMAP_NAVIGATION_CONTROL_ZOOM: BMap.NavigationControlType;
 declare const BMAP_MAPTYPE_CONTROL_HORIZONTAL: BMap.MapTypeControlType;
 declare const BMAP_MAPTYPE_CONTROL_DROPDOWN: BMap.MapTypeControlType;
 declare const BMAP_MAPTYPE_CONTROL_MAP: BMap.MapTypeControlType;
+
+/**
+ * 设置当前的绘制模式
+ * - `BMAP_DRAWING_MARKER` 画点
+ * - `BMAP_DRAWING_CIRCLE` 画圆
+ * - `BMAP_DRAWING_POLYLINE` 画线
+ * - `BMAP_DRAWING_POLYGON` 画多边形
+ * - `BMAP_DRAWING_RECTANGLE` 画矩形
+ */
+declare const BMAP_DRAWING_MARKER: BMap.DrawingType;
+declare const BMAP_DRAWING_CIRCLE: BMap.DrawingType;
+declare const BMAP_DRAWING_POLYLINE: BMap.DrawingType;
+declare const BMAP_DRAWING_POLYGON: BMap.DrawingType;
+declare const BMAP_DRAWING_RECTANGLE: BMap.DrawingType;
 
 /**
  * 此常量用于描述对象当前状态。

--- a/src/utils/requireScript.ts
+++ b/src/utils/requireScript.ts
@@ -3,6 +3,31 @@ const headElement = document.head || document.getElementsByTagName('head')[0];
 const _importedScript: { [src: string]: true } = {};
 
 /**
+ * load dependency by css tag
+ */
+export function requireCss(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (src in _importedScript) {
+      resolve();
+      return
+    }
+    const script = document.createElement('link');
+    script.type = 'text/css';
+    script.rel = "stylesheet"
+    script.href = src
+    script.onerror = err => {
+      headElement.removeChild(script);
+      reject(new URIError(`The css ${src} is no accessible.`));
+    }
+    script.onload = () => {
+      _importedScript[src] = true;
+      resolve();
+    }
+    headElement.appendChild(script);
+  })
+}
+
+/**
  * load dependency by script tag
  */
 export function requireScript(src: string): Promise<void> {
@@ -13,7 +38,7 @@ export function requireScript(src: string): Promise<void> {
     }
     const script = document.createElement('script');
     script.type = 'text/javascript';
-    script.id="_react_baidu_map"
+    script.id = "_react_baidu_map"
     script.src = src;
     script.onerror = err => {
       headElement.removeChild(script);

--- a/website/pages/drawing-manager/index.tsx
+++ b/website/pages/drawing-manager/index.tsx
@@ -1,0 +1,8 @@
+import { useRef, useEffect, useState } from 'react';
+import Markdown from '../../components/Markdown';
+import { APILoader, Map, useMap, DrawingManager, useDrawingManager } from '../../../'; 
+
+export default class Page extends Markdown {
+  dependencies = { APILoader, Map, useMap, DrawingManager, useDrawingManager, useRef, useEffect, useState };
+  getMdStr = () => import('../../../src/DrawingManager/README.md');
+}

--- a/website/router.tsx
+++ b/website/router.tsx
@@ -90,6 +90,10 @@ export const routes: Routes = [
     component: loadable(() => import('./pages/curve-line'), options),
   },
   {
+    path: "/drawing-manager",
+    component: loadable(() => import('./pages/drawing-manager'), options),
+  },
+  {
     path: "/polygon",
     component: loadable(() => import('./pages/polygon'), options),
   },
@@ -224,6 +228,10 @@ export const menus = [
   {
     label: 'CurveLine 弧线组件',
     path: '/curve-line',
+  },
+  {
+    label: 'DrawingManager 鼠标绘制工具条库',
+    path: '/drawing-manager',
   },
   {
     divider: true,


### PR DESCRIPTION
1. 更新 `typescript` 到 3.8 以上，以解决不支持 `import type` 语法
2. `fix typescript` 升级到3.8以后出现 `Argument of type 'ReactPortal' is not assignable to parameter of type 'SetStateAction<undefined>'`
3. 添加鼠标绘制工具条库 `DrawingManager`
4. `Fix` 如果 `bMapLib` 加载过，再次加载会出现的错误
5. 添加 `requireCss`