### PR TITLE
修复 IconSequence 和 getDistance 的一些类型错误

### DIFF
--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -118,7 +118,7 @@ declare namespace BMap {
     /**
      * 返回两点之间的距离，单位是米
      */
-    getDistance(start: Point, end: Point): void;
+    getDistance(start: Point, end: Point): Number;
     /**
      * 返回地图类型
      */

--- a/packages/types/src/overlay.d.ts
+++ b/packages/types/src/overlay.d.ts
@@ -244,7 +244,7 @@ declare namespace BMap {
     strokeWeight?: number;
   }
   class IconSequence {
-    constructor(symbol: symbol, offset?: string, repeat?: string, fixedRotation?: boolean);
+    constructor(symbol: Symbol, offset?: string, repeat?: string, fixedRotation?: boolean);
   }
   interface PointCollection extends Overlay {
     /**


### PR DESCRIPTION
IconSequence 的 constructor 第一个参数是 BMap.Symbol 类型 [参见](https://lbsyun.baidu.com/cms/jsapi/reference/jsapi_reference_3_0.html#a3b13)
getDistance 的返回值应该是 Number [参见](https://lbsyun.baidu.com/cms/jsapi/reference/jsapi_reference_3_0.html#a0b0)